### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ echo http://$NODE_IP:$NODE_PORT
 ```
 You should see something like:
 ```
-http://192.168.99.100:32595
+https://192.168.99.100:32595
 ```
 
 In a separate terminal, start ngrok (substituting your actual URL):
@@ -46,7 +46,7 @@ ngrok http 192.168.99.100:32595
 You should see some output including something like:
 
 ```
-Forwarding                    http://a61d8bb0.ngrok.io -> 192.168.99.100:32595
+Forwarding                    https://a61d8bb0.ngrok.io -> 192.168.99.100:32595
 ```
 
 === Build the Docker container for the function code
@@ -119,7 +119,7 @@ NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S
 riff-http-gateway        LoadBalancer   10.51.247.194   104.154.118.171   80:30725/TCP   22m
 ```
 
-We can see from the `EXTERNAL-IP` and `PORT(S)` columns that our gateway is on `http://104.154.118.171:80`
+We can see from the `EXTERNAL-IP` and `PORT(S)` columns that our gateway is on `https://104.154.118.171:80`
 in this case.
 
 Another convenient way to get the URL is:


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://104.154.118.171:80 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://104.154.118.171:80 ([https](https://104.154.118.171:80) result ConnectTimeoutException).
* http://192.168.99.100:32595 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32595 ([https](https://192.168.99.100:32595) result ConnectTimeoutException).
* http://a61d8bb0.ngrok.io (404) with 1 occurrences migrated to:  
  https://a61d8bb0.ngrok.io ([https](https://a61d8bb0.ngrok.io) result 404).